### PR TITLE
Allow Enter to toggle resize mode

### DIFF
--- a/tools/Resize.lua
+++ b/tools/Resize.lua
@@ -409,6 +409,28 @@ Tools.Resize.showHandles = function ( self, Part )
 				Item.Anchored = true;
 
 			end;
+		
+			self.Connections.EnterButtonListener = Mouse.KeyDown:connect( function ( key )
+
+				local key = key:lower();
+				local key_code = key:byte();
+
+				-- If the Enter button is pressed
+				if key_code == 13 then
+
+					if Tools.Resize.Options.directions == "normal" then
+	
+						Tools.Resize.Options.directions = "both"
+						
+					else
+						
+						Tools.Resize.Options.directions = "normal"
+
+					end;
+
+				end;
+		
+			end );
 
 			-- Return stuff to normal once the mouse button is released
 			self.Connections.HandleReleaseListener = Mouse.Button1Up:connect( function ()


### PR DESCRIPTION
When Enter is pressed, switch the resize mode to both if it's on normal, or vice versa.