### PR TITLE
Removed NetworkServer instantiating

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -54,12 +54,6 @@ if plugin then
 	-- Create the toolbar button
 	ToolbarButton = plugin:CreateToolbar( 'Building Tools by F3X' ):CreateButton( '', 'Building Tools by F3X', Assets.PluginIcon );
 
-	-- Initiate a server only if not in solo testing mode
-	-- (checked in a potentially unreliable way)
-	wait( 3 );
-	if Services.Players.NumPlayers == 0 then
-		Game:GetService 'NetworkServer';
-	end;
 elseif Tool:IsA 'Tool' then
 	ToolType		= 'tool';
 	GUIContainer	= Player:WaitForChild 'PlayerGui';


### PR DESCRIPTION
As of Thursday, a NetworkServer is no longer needed to make http requests using HttpService in a plugin.